### PR TITLE
Fix logging and force folder creation for JSON export

### DIFF
--- a/Download Records.ps1
+++ b/Download Records.ps1
@@ -86,7 +86,6 @@ $configArray = @(
     #}
 ) 
 
-
 function Log($Text) {
 
     $Text = "$(Get-Date -Format g) $Text";
@@ -187,17 +186,18 @@ function GetRec($EC, $R) {
     Log("Processing Record: $($R.id)")
 
     if ($EC.exportJSON) {
-        if (Test-Path $EC.exportJSONPath) {            
-            Log("Export JSON")
-            $httpString = "https://platform.smapone.com/backend/intern/Smaps/$($R.smapId)/Versions/$($R.version)/Data/$($R.id).json?markAsExported=false&useDefault=false&accesstoken=$($EC.token)"
-            $jsonName = $ExecutionContext.InvokeCommand.ExpandString($EC.exportJSONName) -replace "`n", "" -replace "`r", ""; 
-            doWebRequestDownloadFile -uriString $httpString -path $EC.exportJSONPath -fileName $jsonName
-        } else {
-            Log("Pfad nicht vorhanden: $($EC.exportJSONPath)")
+        $exportJSONPath = $ExecutionContext.InvokeCommand.ExpandString($EC.exportJSONPath);
+        if (!(Test-Path $exportJSONPath)) {
+            Log("Create Folder: $($exportJSONPath)")
+            New-Item -ItemType Directory -Force -Path $exportJSONPath | Out-Null
         }
+        Log("Export JSON")
+        $httpString = "https://platform.smapone.com/backend/intern/Smaps/$($R.smapId)/Versions/$($R.version)/Data/$($R.id).json?markAsExported=false&useDefault=false&accesstoken=$($EC.token)"
+        $jsonName = $ExecutionContext.InvokeCommand.ExpandString($EC.exportJSONName) -replace "`n", "" -replace "`r", ""; 
+        doWebRequestDownloadFile -uriString $httpString -path $EC.exportJSONPath -fileName $jsonName
+        
     }
 
-    
     if ($EC.exportPDF) {
         $exportPDFPath = $ExecutionContext.InvokeCommand.ExpandString($EC.exportPDFPath);
         if (!(Test-Path $exportPDFPath)) {

--- a/Download Records.ps1
+++ b/Download Records.ps1
@@ -232,7 +232,7 @@ function GetRec($EC, $R) {
             $httpString = "https://platform.smapone.com/backend/intern/Smaps/$($R.smapId)/Versions/$($R.version)/Data/$($R.id)/Files/$($jsonRec.fileId)?accesstoken=$($EC.token)"
             $assetName = $jsonRec.fileName;
             if (!($assetName.StartsWith("Signature_"))) {
-                Log("Write File: $($exportAssetsPath)\$($assetName)")
+                # Log("Write File: $($exportAssetsPath)\$($assetName)")
                 doWebRequestDownloadFile -uriString $httpString -path $exportAssetsPath -fileName $assetName                
             }
         }


### PR DESCRIPTION
There was double logging for asset file export in lines 247 and 163 which was removed.

And when trying to write JSON files, the export fails if the folder doesn't exist. This is now changed to the same behaviour as with PDF reports (force folder creation).